### PR TITLE
Implement Match details view

### DIFF
--- a/ts/src/AbuseFilter.ts
+++ b/ts/src/AbuseFilter.ts
@@ -75,9 +75,12 @@ export class AbuseFilter {
         this.transformWith(transformer);
     }
 
-    public renderInto(container: HTMLElement, treeFilters: ITreeFilter[] = []): void {
-        const gui = new AbuseFilterGUI(container, treeFilters);
-        const viewFactory = new ViewFactory();
+    public renderInto(container: HTMLElement, options: Partial<RenderOptions> = {}): void {
+        options.treeFilters = options.treeFilters || [];
+        options.viewFactory = options.viewFactory || new ViewFactory();
+        
+        const gui = new AbuseFilterGUI(container, options.treeFilters);
+        const viewFactory = options.viewFactory;
         viewFactory.addDataViewFactory(
             // check if node is IEvaluableTreeNode
             (node) => 'getValue' in node
@@ -112,3 +115,7 @@ export class AbuseFilter {
 }
 
 type TreeWalkerCallback = (node: IEvaluableTreeNode, value: IValue, depth: number) => void;
+type RenderOptions = {
+    treeFilters: ITreeFilter[],
+    viewFactory: ViewFactory,
+};

--- a/ts/src/gadgets/hitDetails/AugmentedOperatorNodeView.ts
+++ b/ts/src/gadgets/hitDetails/AugmentedOperatorNodeView.ts
@@ -1,0 +1,87 @@
+import { IView } from '../../gui/IView.js';
+import { INodeView } from '../../gui/treeViews/INodeView.js';
+import { OperatorNodeView } from '../../gui/treeViews/OperatorNodeView.js';
+import { IEvaluationContext } from '../../model/IEvaluationContext.js';
+import { IEvaluableTreeNode } from '../../model/nodes/IEvaluableTreeNode.js';
+import { IValue } from '../../model/value/IValue.js';
+import { MatchingMode, PatternExplorerPopup } from './PatternExplorerPopup.js';
+
+export class AugmentedOperatorNodeView extends OperatorNodeView {
+    protected readonly evaluationContext: IEvaluationContext;
+
+    public constructor(node: IEvaluableTreeNode, childViews: INodeView[], dataView: IView, evaluationContext: IEvaluationContext) {
+        super(node, childViews, dataView);
+        this.evaluationContext = evaluationContext;
+    }
+
+    protected createTokenNode(token: string, classes: string[] = []): HTMLElement {
+        const treeNode = this.treeNode as IEvaluableTreeNode;
+
+        const element = document.createElement('button');
+        element.classList.add('afa-token', 'afa-silent-button');
+        if (classes.length > 0) {
+            element.classList.add(...classes);
+        }
+        element.append(token);
+
+        const buttonTitle = 'Click to see details of the match';
+        // Enable the button only if the node matched anything in the current context
+        element.disabled = treeNode.getValue(this.evaluationContext).isTruthy() !== true;
+        if (!element.disabled) {
+            element.title = buttonTitle;
+        }
+        treeNode.addOnValueSetCallback((_, ec) => {
+            if (ec !== this.evaluationContext) return;
+            element.disabled = treeNode.getValue(ec).isTruthy() !== true;
+            if (!element.disabled) {
+                element.title = buttonTitle;
+            }
+        });
+
+        element.addEventListener('click', () => {
+            this.displayPopup(element);
+        });
+        return element;
+    }
+
+    protected displayPopup(anchor: HTMLElement): void {
+        const children = (this.treeNode as IEvaluableTreeNode).children;
+        const argValues = children.map(child => child.getValue(this.evaluationContext));
+        const args = this.interpretArguments(argValues, this.treeNode.identity.value);
+
+        const popup = new PatternExplorerPopup(args.pattern, args.subject, args.mode);
+        popup.display(anchor);
+    }
+
+    /**
+     * Decodes the order of the arguments, depending on the operator.
+     * @param values The operands of the operator
+     * @param operator The operator
+     * @returns Returns an object with two properties: subject (the whole tested string) and pattern (regex/glob pattern or substring)
+     */
+    private interpretArguments(values: IValue[], operator: string): { subject: IValue, pattern: IValue, mode: MatchingMode } {
+        const modes = {
+            'in': 'substring',
+            'contains': 'substring',
+            'like': 'glob',
+            'matches': 'glob',
+            'regex': 'regex',
+            'rlike': 'regex',
+            'irlike': 'regex-i',
+        } as Record<string, MatchingMode>;
+        
+        if (operator === 'in') {
+            return {
+                subject: values[1],
+                pattern: values[0],
+                mode: modes[operator] as MatchingMode
+            };
+        } else {
+            return {
+                subject: values[0],
+                pattern: values[1],
+                mode: modes[operator] as MatchingMode
+            };
+        }
+    }
+}

--- a/ts/src/gadgets/hitDetails/PatternExplorerPopup.ts
+++ b/ts/src/gadgets/hitDetails/PatternExplorerPopup.ts
@@ -1,0 +1,112 @@
+import { Match, ValueStringOperations } from '../../evaluator/value/ValueStringOperations.js';
+import { ValueFormatter } from '../../gui/value/ValueFormatter.js';
+import { IValue } from '../../model/value/IValue.js';
+
+export type MatchingMode = 'regex' | 'regex-i' | 'glob' | 'substring';
+export class PatternExplorerPopup {
+    protected readonly pattern: IValue;
+    protected readonly subject: IValue;
+    protected readonly matchingMode: MatchingMode;
+
+    /**
+     * Creates a new PatternExplorerPopup instance.
+     * @param pattern The regex/glob pattern or substring to be searched for
+     * @param subject The whole tested string
+     * @param matchingMode The matching mode, which can be 'regex', 'glob', or 'substring'
+     */
+    public constructor(pattern: IValue, subject: IValue, matchingMode: MatchingMode) {
+        this.pattern = pattern;
+        this.subject = subject;
+        this.matchingMode = matchingMode;
+    }
+
+    public display(attachToNode: HTMLElement | null): void {
+        const content = document.createElement('div');
+        content.append(this.makePatternBlock());
+        content.append(this.makeSubjectBlock());
+
+        const $anchor = attachToNode ? $(attachToNode) : undefined;
+
+        // Adjust the popup width based on the values to be shown
+        const useWidePopup = this.isLongValue(this.pattern) || this.isLongValue(this.subject);
+
+        mw.loader.using(['oojs-ui-core', 'oojs-ui-widgets'], () => {
+            const popup = new OO.ui.PopupWidget({
+                autoClose: true,
+                padded: true,
+                width: useWidePopup ? window.innerWidth * 0.9 : 350,
+                $content: $(content),
+                $floatableContainer: $anchor,
+                anchor: !!attachToNode,
+                head: true,
+                label: 'Match details',
+            });
+            
+            $(document.body).append(popup.$element);
+            popup.toggle(true);
+        });
+    }
+
+    protected makePatternBlock(): HTMLElement {
+        const patternBlock = document.createElement('p');
+        patternBlock.append('Pattern: ');
+        patternBlock.append(ValueFormatter.formatValue(this.pattern, 100));
+        return patternBlock;
+    }
+
+    protected makeSubjectBlock(): HTMLElement {
+        let match: Match | null = null;
+        if (this.matchingMode === 'substring') {
+            match = ValueStringOperations.matchSubstring(this.subject, this.pattern);
+        } else if (this.matchingMode === 'glob') {
+            match = ValueStringOperations.matchGlob(this.subject, this.pattern);
+        } else {
+            match = ValueStringOperations.matchRegex(this.subject, this.pattern, this.matchingMode === 'regex-i');
+        }
+
+        if (match === null) {
+            console.log(`PatternExplorerPopup: No match found for pattern "${this.pattern.asString().value}" in subject "${this.subject.asString().value}". Matching mode: ${this.matchingMode}`);
+            const noMatchBlock = document.createElement('p');
+            noMatchBlock.textContent = 'No match found';
+            return noMatchBlock;
+        }
+
+        // This intentionally does not format the subject as usual, because it it
+        // for sure a string and we don't want to be sensitive to what the formatter does.
+        return this.extractAndHighlightMatch(this.subject.asString().value!, match, 250);
+    }
+
+    protected isLongValue(value: IValue): boolean {
+        // A value is considered long if it has more than 40 characters
+        return value.asString().value!.length > 40;
+    }
+
+    protected extractAndHighlightMatch(str: string, match: Match, windowSize: number): HTMLElement {
+        const wrapper = document.createElement('p');
+        wrapper.classList.add('afa-value', 'afa-value-string');
+        wrapper.append('"');
+        if (match.start > 0) {
+            const fragmentStart = match.start < windowSize ? 0 : match.start - windowSize;
+            const leadingFragment = str.substring(fragmentStart, match.start);
+            wrapper.append(ValueFormatter.escapeString(leadingFragment));
+        }
+
+        const highlightedPart = document.createElement('mark');
+        const matchedFragment = str.substring(match.start, match.end);
+        highlightedPart.textContent = ValueFormatter.escapeString(matchedFragment);
+        wrapper.appendChild(highlightedPart);
+
+        if (match.end < str.length) {
+            const fragmentEnd = match.end + windowSize < str.length ? match.end + windowSize : str.length;
+            const trailingFragment = str.substring(match.end, fragmentEnd);
+            wrapper.append(ValueFormatter.escapeString(trailingFragment));
+        }
+        wrapper.append('"');
+        return wrapper;
+    }
+}
+
+export type ValueFrequencies = {
+    value: IValue,
+    count: number
+}[];

--- a/ts/src/gadgets/hitDetails/ViewFactoryWithAugmented.ts
+++ b/ts/src/gadgets/hitDetails/ViewFactoryWithAugmented.ts
@@ -1,0 +1,33 @@
+import { INodeView } from '../../gui/treeViews/INodeView.js';
+import { ViewFactory } from '../../gui/treeViews/ViewFactory.js';
+import { IEvaluationContext } from '../../model/IEvaluationContext.js';
+import { IEvaluableTreeNode } from '../../model/nodes/IEvaluableTreeNode.js';
+import { TreeNodeType } from '../../model/nodes/TreeNodeType.js';
+import { AugmentedOperatorNodeView } from './AugmentedOperatorNodeView.js';
+
+export class ViewFactoryWithAugmented extends ViewFactory {
+    protected readonly evaluationContext: IEvaluationContext;
+
+    public constructor(evaluationContext: IEvaluationContext) {
+        super();
+        this.evaluationContext = evaluationContext;
+    }
+
+    protected createViewWithChildren(node: IEvaluableTreeNode, childViews: INodeView[]): INodeView {
+        if (!('getValue' in node)) {
+            throw new Error('Only evaluable nodes can be used with this view factory');
+        }
+
+        const augmentedOperators = ['in', 'contains', 'like', 'matches', 'regex', 'rlike', 'irlike'];
+
+        if (
+            node.type === TreeNodeType.Operator
+            && augmentedOperators.includes(node.identity.value)
+        ) {
+            const dataView = this.createDataView(node);
+            return new AugmentedOperatorNodeView(node, childViews, dataView, this.evaluationContext);
+        }
+
+        return super.createViewWithChildren(node, childViews);
+    }
+}

--- a/ts/src/gadgets/hitDetails/main.ts
+++ b/ts/src/gadgets/hitDetails/main.ts
@@ -6,6 +6,8 @@
  * values of all the nodes in it.
  */
 
+import { ViewFactoryWithAugmented } from './ViewFactoryWithAugmented.js';
+
 mw.hook('userjs.abuseFilter').add((abuseFilter: typeof mw.libs.abuseFilter) => {
     // Run only on the AbuseLog special page
     if (mw.config.get('wgCanonicalSpecialPageName') !== 'AbuseLog') return;
@@ -41,7 +43,10 @@ mw.hook('userjs.abuseFilter').add((abuseFilter: typeof mw.libs.abuseFilter) => {
             const filters = [
                 impactingBoolFilter,
             ];
-            filter.renderInto(rootElement, filters);
+            filter.renderInto(rootElement, {
+                treeFilters: filters,
+                viewFactory: new ViewFactoryWithAugmented(filter.defaultContext),
+            });
             await filter.evaluate();
         } catch (error: unknown) {
             const errorMessage = (error instanceof Error) ? error.message : ('' + error);

--- a/ts/src/gui/value/ValueFormatter.ts
+++ b/ts/src/gui/value/ValueFormatter.ts
@@ -73,11 +73,7 @@ export class ValueFormatter {
 
     private static formatStringLiteral(value: string, maxLength?: number): HTMLElement {
         const wrapper = this.makeWrapper('string');
-        const escapedValue = value
-            .replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r');
+        const escapedValue = this.escapeString(value);
 
         if (maxLength !== undefined && value.length > maxLength) {
             wrapper.append('"');
@@ -135,5 +131,14 @@ export class ValueFormatter {
             clickHandler();
         });
         return button;
+    }
+
+    /** Escapes special characters in a string for display in double quotes */
+    public static escapeString(value: string): string {
+        return value
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"')
+            .replace(/\n/g, '\\n')
+            .replace(/\r/g, '\\r');
     }
 }

--- a/ts/src/public_api.ts
+++ b/ts/src/public_api.ts
@@ -142,8 +142,23 @@ mw.util.addCSS(`
 .afa-filter-wrapper label {
     margin-left: 0.6em;
 }
+.afa-silent-button {
+    background: none;
+    font: inherit;
+    appearance: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    cursor: pointer;
+    outline: inherit;
+    text-align: left;
+    margin: 0;
+}
+.afa-silent-button[disabled] {
+    cursor: default;
+}
 
-.afa-value, .afa-token { font-family: monospace; word-break: break-all; }
+.afa-value, .afa-token { font-family: monospace; word-break: break-all; white-space-collapse: preserve; }
 .afa-value-keyword { color: var(--afa-color-value-keyword); }
 .afa-value-string { color: var(--afa-color-value-string); }
 .afa-value-number { color: var(--afa-color-value-number); }
@@ -220,18 +235,6 @@ mw.util.addCSS(`
     padding-left: 1em;
 }
 
-button.afa-silent-button {
-    background: none;
-    font: inherit;
-    appearance: none;
-    border: none;
-    padding: 0;
-    color: inherit;
-    cursor: pointer;
-    outline: inherit;
-    text-align: left;
-    margin: 0;
-}
 .afa-value-inlay-button {
     background: var(--background-color-neutral, #eaecf0);
     font-size: 0.85em;


### PR DESCRIPTION
It provides a popup available for operators like `regex` `glob` and `in`, which presents the subject string on which the match was done and highlights the matched part.
This feature will make it even easier to understand why the filter was matched to a specific action.

Closes #24 